### PR TITLE
Fix rare crash when rolling shop

### DIFF
--- a/TarotDx.lua
+++ b/TarotDx.lua
@@ -1535,10 +1535,11 @@ function get_pack(_key, _type)
             end
         end
 
-        return center
-    else
-        return get_pack_ref(_key, _type)
+        if center ~= nil then
+            return center
+        end
     end
+    return get_pack_ref(_key, _type)
 end
 
 -- Overwrite level_up_hand if planet edition is enabled 


### PR DESCRIPTION
Possibly due to use in conjunction with another mod (Betmma Vouchers?), rolling the shop could sometimes crash the game by indexing a nil value. Adding a failsafe to get_pack() to stop it from returning nil seems to prevent this.