### PR TITLE
Improved curse debuff logic

### DIFF
--- a/TarotDx.lua
+++ b/TarotDx.lua
@@ -3515,14 +3515,12 @@ local function overrides()
         -- Check for suit buff
         if self.base and self.base.suit and G.GAME.used_cu_augments and ((self.base.suit == 'Diamonds' and G.GAME.used_cu_augments.c_star_cu) or (self.base.suit == 'Clubs' and G.GAME.used_cu_augments.c_moon_cu) or (self.base.suit == 'Hearts' and G.GAME.used_cu_augments.c_sun_cu) or (self.base.suit == 'Spades' and G.GAME.used_cu_augments.c_world_cu)) then   -- Overwrite
             self.debuff = false
-            self.params.debuff_by_curse = nil
-        -- Check if the debuff is from a curse
-        elseif not should_debuff and self.params.debuff_by_curse then
-            card_set_debuff_ref(self, self.params.debuff_by_curse)
-        -- Vanilla
-        else
-            card_set_debuff_ref(self, should_debuff)
+            self.ability.debuff_by_curse_rolls = {}
+            return
         end
+        -- OR with vanilla boolean
+        local custom_debuff = custom_debuff_card(self)
+        card_set_debuff_ref(self, should_debuff or custom_debuff)
     end
 
     -- Manage custom sprites

--- a/source/alchemical_dx.lua
+++ b/source/alchemical_dx.lua
@@ -1162,7 +1162,6 @@ function load_dx_alchemical_cards()
             for k, v in ipairs(G.hand.cards) do
                 delay(0.05)
                 v:juice_up(1, 0.5)
-                v.params.debuff_by_curse = nil
                 v:set_debuff(false)
                 v.config = v.config or {}
                 v.config.oil = true
@@ -1187,7 +1186,6 @@ function load_dx_alchemical_cards()
             for k, v in ipairs(G.hand.cards) do
                 delay(0.05)
                 v:juice_up(1, 0.5)
-                v.params.debuff_by_curse = nil
                 v:set_debuff(false)
                 v.ability.extra = v.ability.extra or {}
                 v.ability.extra.oil = true

--- a/source/curse.lua
+++ b/source/curse.lua
@@ -363,8 +363,8 @@ local function setUpLocalizationCurses()
         cu_pillar = {
             name = "Lift condition",
             text = {
-                "Play {C:blue}#1#{} hands with",
-                "{C:attention}5 debuffed scoring cards{}",
+                "Play {C:blue}#1#{} hands containing",
+                "a {C:attention}debuffed scoring{} card",
                 "{C:inactive}(Progress: #2#/#1#){}"
             }
         },

--- a/source/curse.lua
+++ b/source/curse.lua
@@ -766,7 +766,9 @@ local function override()
         local text, disp_text, poker_hands, scoring_hand, non_loc_disp_text = G.FUNCS.get_poker_hand_info(cards)
 
         if (G.GAME.curses) then
+            local update_debuffs = false -- curses that debuff cards might be lifted
             for k, v in pairs(G.GAME.curses) do
+                local already_lifted = v.lifts >= v.config.lift
                 if v.config.type == 'curse' and (v.lifts < v.config.lift) then
                     if v.name == 'The Psychic' and #cards < 5 and not check then
                         v.triggered = true
@@ -863,12 +865,24 @@ local function override()
                         end
                         v.lifts = v.lifts + (scoring and 1 or 0)
                     end
+                    if (
+                        v.name == 'The Goad' or v.name == 'The Head'
+                        or v.name == 'The Club' or v.name == 'The Window'
+                        or v.name == 'The Plant' or v.name == 'The Pillar'
+                    ) and not already_lifted and v.lifts >= v.config.lift then
+                        update_debuffs = true
+                    end
                     if v.name == 'The Flint' then
                         v.lifts = v.lifts + 1
                     end
                     if v.name == 'The Tooth' then
                         v.lifts = v.lifts + #cards
                     end
+                end
+            end
+            if update_debuffs then
+                for _, v in ipairs(G.playing_cards) do
+                    self:debuff_card(v)
                 end
             end
         end

--- a/source/curse.lua
+++ b/source/curse.lua
@@ -650,40 +650,34 @@ local function override()
     ----- Curses effects -----
 
     -- Manage curses debuff
-    function custom_debuff_card(curse, card)
-
-        if card and curse then
-            if curse.name == 'The Goad' and card:is_suit('Spades', true) and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
-            end
-            if curse.name == 'The Plant' and card:is_face(true) and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
-            end
-            if curse.name == 'The Head' and card:is_suit('Hearts', true) and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
-            end
-            if curse.name == 'The Club' and card:is_suit('Clubs', true) and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
-            end
-            if curse.name == 'The Window' and card:is_suit('Diamonds', true) and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
-            end
-            if curse.name == 'The Pillar' and card.ability.played_this_ante and is_curse_triggered(curse) then
-                card.params.debuff_by_curse = true
-                card:set_debuff(true)
-                return
+    function custom_debuff_card(card)
+        card.ability.debuff_by_curse_rolls = card.ability.debuff_by_curse_rolls or {}
+        if G.GAME.curses then
+            for _, curse in ipairs(G.GAME.curses) do
+                if curse.config.type == 'curse' and (curse.lifts < curse.config.lift) then
+                    if curse.name == 'The Goad' and card:is_suit('Spades', true)
+                    or curse.name == 'The Plant' and card:is_face(true)
+                    or curse.name == 'The Head' and card:is_suit('Hearts', true)
+                    or curse.name == 'The Club' and card:is_suit('Clubs', true)
+                    or curse.name == 'The Window' and card:is_suit('Diamonds', true)
+                    or curse.name == 'The Pillar' and card.ability.played_this_ante then
+                        if card.ability.debuff_by_curse_rolls[curse.name] == nil then
+                            card.ability.debuff_by_curse_rolls[curse.name] = is_curse_triggered(curse)
+                        end
+                    else
+                        -- clear this roll, the card might have changed such that
+                        -- it isn't affected by the curse anymore
+                        -- (such as using a Tarot card)
+                        card.ability.debuff_by_curse_rolls[curse.name] = nil
+                    end
+                end
             end
         end
+        -- OR all rolls to obtain final value of debuff_by_curse
+        for k, v in pairs(card.ability.debuff_by_curse_rolls) do
+            if v then return true end
+        end
+        return false
     end
 
     ---------- state_events ----------
@@ -1019,21 +1013,18 @@ local function override()
                             }))
                         end
                     end
-                    if (v.name == 'The Goad' or v.name == 'The Plant' or v.name == 'The Head' or v.name == 'The Club' or v.name == 'The Window' or v.name == 'The Pillar') and not v.triggered then
-                        v.triggered = true
-                        G.E_MANAGER:add_event(Event({
-                            trigger = 'after',
-                            delay =  0.7,
-                            func = (function() 
-                                    for _, cv in ipairs(G.playing_cards) do
-                                        custom_debuff_card(v, cv)
-                                    end
-                                    v:juice_up(0.3, 0.2)
-                                    play_sound('tarot2', 0.76, 0.4)
-                                return true
-                            end)
-                        }))
-                    end
+                    -- if (v.name == 'The Goad' or v.name == 'The Plant' or v.name == 'The Head' or v.name == 'The Club' or v.name == 'The Window' or v.name == 'The Pillar') and not v.triggered then
+                    --     v.triggered = true
+                    --     G.E_MANAGER:add_event(Event({
+                    --         trigger = 'after',
+                    --         delay =  0.7,
+                    --         func = (function() 
+                    --                 v:juice_up(0.3, 0.2)
+                    --                 play_sound('tarot2', 0.76, 0.4)
+                    --             return true
+                    --         end)
+                    --     }))
+                    -- end
                 end
 
                 if v.config.type == 'final_curse' and (not reset) and (not silent) then
@@ -1125,9 +1116,7 @@ local function override()
     function Blind.defeat(self, silent)
         
         for k, v in pairs(G.playing_cards) do
-            if v.params.debuff_by_curse then
-                v.params.debuff_by_curse = nil
-            end
+            v.ability.debuff_by_curse_rolls = nil
         end
 
         blind_defeat_ref(self, silent)


### PR DESCRIPTION
- Existing curse rolls are saved and never rerolled until the blind is defeated
- If a card is copied, curse rolls are copied too (consistent with vanilla)
- If a card changes suit, say, and a curse becomes inapplicable, that curse roll is cleared.
  - If that card changes back to a suit for which that curse becomes applicable, a new curse roll is added